### PR TITLE
feat: add controlled Hashnode publishing workflow

### DIFF
--- a/.github/workflows/hashnode-draft.yml
+++ b/.github/workflows/hashnode-draft.yml
@@ -1,4 +1,4 @@
-name: Create Hashnode Draft
+name: Controlled Hashnode Publish
 
 on:
   workflow_dispatch:
@@ -7,47 +7,83 @@ on:
         description: "Markdown file path in this repository"
         required: true
         type: string
+      action:
+        description: "Hashnode operation to run"
+        required: true
+        default: "draft"
+        type: choice
+        options:
+          - validate
+          - api-check
+          - draft
+          - update-draft
+          - publish-draft
+          - publish
+          - update-post
       raw_ref:
         description: "Git ref used for raw GitHub image URLs. Leave blank to use the workflow ref."
         required: false
         type: string
+      draft_id:
+        description: "Draft ID override for update-draft / publish-draft"
+        required: false
+        type: string
+      post_id:
+        description: "Post ID override for update-post"
+        required: false
+        type: string
+      write_back:
+        description: "Write created draft/post IDs back to the markdown file and commit them"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  create-draft:
-    name: Create draft from Markdown
+  hashnode:
+    name: Hashnode ${{ inputs.action }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate inputs
         shell: bash
-        run: |
-          set -euo pipefail
-          if [ ! -f "${{ inputs.markdown_file }}" ]; then
-            echo "Markdown file not found: ${{ inputs.markdown_file }}" >&2
-            exit 1
-          fi
-          if [ -z "${HASHNODE_API_TOKEN:-}" ]; then
-            echo "Missing GitHub secret: HASHNODE_API_TOKEN" >&2
-            exit 1
-          fi
-          if [ -z "${HASHNODE_PUBLICATION_ID:-}" ] && [ -z "${HASHNODE_PUBLICATION_HOST:-}" ]; then
-            echo "Set either HASHNODE_PUBLICATION_ID secret or HASHNODE_PUBLICATION_HOST variable" >&2
-            exit 1
-          fi
         env:
+          ACTION: ${{ inputs.action }}
+          MARKDOWN_FILE: ${{ inputs.markdown_file }}
           HASHNODE_API_TOKEN: ${{ secrets.HASHNODE_API_TOKEN }}
           HASHNODE_PUBLICATION_ID: ${{ secrets.HASHNODE_PUBLICATION_ID }}
           HASHNODE_PUBLICATION_HOST: ${{ vars.HASHNODE_PUBLICATION_HOST || secrets.HASHNODE_PUBLICATION_HOST }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "$MARKDOWN_FILE" ]; then
+            echo "Markdown file not found: $MARKDOWN_FILE" >&2
+            exit 1
+          fi
+          if [ "$ACTION" != "validate" ] && [ -z "${HASHNODE_API_TOKEN:-}" ]; then
+            echo "Missing GitHub secret: HASHNODE_API_TOKEN" >&2
+            exit 1
+          fi
+          if [ "$ACTION" != "validate" ] && [ -z "${HASHNODE_PUBLICATION_ID:-}" ] && [ -z "${HASHNODE_PUBLICATION_HOST:-}" ]; then
+            echo "Set either HASHNODE_PUBLICATION_ID secret or HASHNODE_PUBLICATION_HOST variable" >&2
+            exit 1
+          fi
 
-      - name: Create Hashnode draft
+      - name: Run Hashnode action
+        id: hashnode
         shell: bash
         env:
+          ACTION: ${{ inputs.action }}
+          MARKDOWN_FILE: ${{ inputs.markdown_file }}
+          DRAFT_ID: ${{ inputs.draft_id }}
+          POST_ID: ${{ inputs.post_id }}
+          WRITE_BACK: ${{ inputs.write_back }}
           HASHNODE_API_TOKEN: ${{ secrets.HASHNODE_API_TOKEN }}
           HASHNODE_PUBLICATION_ID: ${{ secrets.HASHNODE_PUBLICATION_ID }}
           HASHNODE_PUBLICATION_HOST: ${{ vars.HASHNODE_PUBLICATION_HOST || secrets.HASHNODE_PUBLICATION_HOST }}
@@ -55,6 +91,35 @@ jobs:
         run: |
           set -euo pipefail
           RAW_BASE_URL="https://raw.githubusercontent.com/${{ github.repository }}/${RAW_REF}"
-          python3 scripts/hashnode_create_draft.py \
-            "${{ inputs.markdown_file }}" \
+          args=(
+            "$MARKDOWN_FILE"
+            --action "$ACTION"
             --raw-base-url "$RAW_BASE_URL"
+          )
+          if [ -n "$DRAFT_ID" ]; then
+            args+=(--draft-id "$DRAFT_ID")
+          fi
+          if [ -n "$POST_ID" ]; then
+            args+=(--post-id "$POST_ID")
+          fi
+          if [ "$WRITE_BACK" = "true" ]; then
+            args+=(--write-back)
+          fi
+          python3 scripts/hashnode_create_draft.py "${args[@]}" | tee hashnode-result.json
+
+      - name: Commit write-back changes
+        if: ${{ inputs.write_back == true }}
+        shell: bash
+        env:
+          MARKDOWN_FILE: ${{ inputs.markdown_file }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$MARKDOWN_FILE"; then
+            echo "No markdown frontmatter changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$MARKDOWN_FILE"
+          git commit -m "chore: update Hashnode metadata for $MARKDOWN_FILE"
+          git push

--- a/docs/hashnode-draft-automation.md
+++ b/docs/hashnode-draft-automation.md
@@ -1,23 +1,25 @@
-# Hashnode draft automation
+# Controlled Hashnode publishing
 
 This repository is currently a Hashnode markdown backup. The workflow at
 `.github/workflows/hashnode-draft.yml` adds the other direction as an explicit,
-manual action:
+manual control surface:
 
 ```text
 Markdown in GitHub
     ↓ workflow_dispatch
-Hashnode draft
+validate / draft / publish-draft / publish / update
+    ↓
+Hashnode
 ```
 
-It does **not** publish posts automatically. It only creates a draft so the
-article can be reviewed in Hashnode before publishing.
+The safe default is `draft`. Nothing is published unless the workflow input is
+explicitly set to `publish-draft` or `publish`.
 
 ## Required Hashnode setup
 
 Hashnode GraphQL API access now requires API access on the publication. If the
-API returns a paid-access error, enable the required plan/API access in the
-Hashnode dashboard first.
+API returns a paid-access error or HTML instead of JSON, enable the required
+plan/API access in the Hashnode dashboard first.
 
 Create a Hashnode Personal Access Token from:
 
@@ -25,50 +27,53 @@ Create a Hashnode Personal Access Token from:
 https://hashnode.com/settings/developer
 ```
 
-Then configure this repository:
+Then configure this repository.
 
 ### GitHub secrets
 
-Required:
+Required for all real Hashnode API calls:
 
 ```text
 HASHNODE_API_TOKEN
 ```
 
-One of these is also required:
+Optional, but preferred because it avoids an extra API lookup:
 
 ```text
 HASHNODE_PUBLICATION_ID
 ```
 
-or configure this repository variable instead:
+### GitHub variables
+
+If `HASHNODE_PUBLICATION_ID` is not configured, set this repository variable:
 
 ```text
 HASHNODE_PUBLICATION_HOST=blog.yu.money
 ```
 
-`HASHNODE_PUBLICATION_ID` is preferred because it avoids an extra API lookup.
-`HASHNODE_PUBLICATION_HOST` is more convenient when setting things up the first
-time.
+`HASHNODE_PUBLICATION_HOST` is intentionally a variable, not a secret.
 
-## How to create a draft
+## Workflow actions
 
-1. Commit the markdown file and any image assets to this repository.
-2. Open GitHub Actions.
-3. Run **Create Hashnode Draft**.
-4. Enter the markdown file path, for example:
+Run **Controlled Hashnode Publish** from GitHub Actions and choose one action:
 
-```text
-posts/hermes-agent-discord-gateway.md
-```
+| Action | What it does |
+| --- | --- |
+| `validate` | Parses the markdown and prints the Hashnode payload. Does not need a token. |
+| `api-check` | Verifies token + publication API access. |
+| `draft` | Creates a draft. If a draft ID already exists, updates that draft. |
+| `update-draft` | Updates an existing draft. Requires `hashnode_draft_id` or workflow `draft_id`. |
+| `publish-draft` | Publishes an existing draft. Requires `hashnode_draft_id` or workflow `draft_id`. |
+| `publish` | Publishes a new post directly. Use carefully. |
+| `update-post` | Updates an existing published post. Requires `hashnode_article_id` or workflow `post_id`. |
 
-or, if the file is at the repo root:
+## Recommended flow
 
-```text
-hermes-agent-discord-gateway.md
-```
-
-The workflow prints the created draft metadata in the logs.
+1. Commit the markdown file and any image assets.
+2. Run `validate` first.
+3. Run `draft` with `write_back=true`.
+4. Review the draft in Hashnode.
+5. Run `publish-draft` when ready.
 
 ## Markdown frontmatter
 
@@ -85,10 +90,20 @@ subtitle: Optional subtitle
 canonical: https://original.example.com/article
 seoTitle: Optional SEO title
 seoDescription: Optional SEO description
+hashnode_action: draft
+hashnode_draft_id:
+hashnode_article_id:
 ---
 ```
 
 `title` is required.
+
+The workflow can write these fields back when `write_back=true`:
+
+```yaml
+hashnode_draft_id: <created draft id>
+hashnode_article_id: <published post id>
+```
 
 ## Images
 
@@ -109,25 +124,53 @@ For permanent production posts, using Hashnode CDN, Cloudinary, R2, or another
 stable image host is still cleaner. GitHub raw URLs are good enough for a safe
 first version of the automation.
 
-## Local dry-run
+## Local validate
 
 From the repository root:
 
 ```bash
-python scripts/hashnode_create_draft.py path/to/article.md \
-  --publication-host blog.yu.money \
-  --dry-run
+python3 scripts/hashnode_create_draft.py path/to/article.md \
+  --action validate
 ```
 
-This validates frontmatter and prints the GraphQL payload without calling
+This validates frontmatter and prints the Hashnode payload without calling
 Hashnode.
 
-## Local real draft creation
+## Local API check
 
 ```bash
 export HASHNODE_API_TOKEN="..."
 export HASHNODE_PUBLICATION_HOST="blog.yu.money"
-python scripts/hashnode_create_draft.py path/to/article.md
+python3 scripts/hashnode_create_draft.py path/to/article.md \
+  --action api-check
 ```
 
-Again, this creates a draft only. It does not publish.
+If the publication does not have API access, the script prints an explicit
+message pointing to Hashnode billing/API access instead of a raw JSON parse
+error.
+
+## Local draft / publish examples
+
+Create or update a draft:
+
+```bash
+python3 scripts/hashnode_create_draft.py path/to/article.md \
+  --action draft \
+  --write-back
+```
+
+Publish an existing draft:
+
+```bash
+python3 scripts/hashnode_create_draft.py path/to/article.md \
+  --action publish-draft \
+  --draft-id <draft id> \
+  --write-back
+```
+
+Publish directly:
+
+```bash
+python3 scripts/hashnode_create_draft.py path/to/article.md \
+  --action publish
+```

--- a/scripts/hashnode_create_draft.py
+++ b/scripts/hashnode_create_draft.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
-"""Create a Hashnode draft from a Markdown file.
+"""Controlled Hashnode publishing from Markdown.
 
-This script is intentionally dependency-free so it can run in GitHub Actions
-without npm/pip install steps.
+Dependency-free helper for GitHub Actions and local use.
 
-Required for real API calls:
-  HASHNODE_API_TOKEN
-  HASHNODE_PUBLICATION_ID or HASHNODE_PUBLICATION_HOST
+Supported actions:
+  validate        Parse frontmatter and print the payload only.
+  api-check       Resolve the publication and verify Hashnode API access.
+  draft           Create a draft, or update an existing draft when draft ID exists.
+  update-draft    Update an existing draft.
+  publish-draft   Publish an existing draft.
+  publish         Publish a new post directly.
+  update-post     Update an existing published post.
 
-Safe default: it only creates a draft. It never publishes a post.
+This script never publishes unless action is explicitly `publish` or
+`publish-draft`.
 """
 
 from __future__ import annotations
@@ -19,31 +24,32 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
 
 HASHNODE_ENDPOINT = "https://gql.hashnode.com"
+PAID_ACCESS_URL = "https://hashnode.com/changelog/2026-05-13-graphql-api-paid-access"
 
 
-def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
-    """Parse a small YAML-frontmatter subset used by Hashnode exports.
+class HashnodeAPIError(RuntimeError):
+    """Raised for actionable Hashnode API errors."""
 
-    Supports:
-    - key: value
-    - quoted strings
-    - comma-separated tags
-    - simple arrays: [a, b, c]
 
-    This is not a full YAML parser. It avoids third-party dependencies on
-    purpose. If a value is too complex, keep it as a string.
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str, str, str]:
+    """Parse a small YAML-frontmatter subset used by this repository.
+
+    Returns (data, body, raw_frontmatter, newline). This is intentionally not a
+    full YAML parser so the workflow can run without dependencies.
     """
+    newline = "\r\n" if "\r\n" in text[:200] else "\n"
     if not text.startswith("---\n") and not text.startswith("---\r\n"):
-        return {}, text
+        return {}, text, "", newline
 
     match = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n?", text, re.DOTALL)
     if not match:
-        return {}, text
+        return {}, text, "", newline
 
     raw_fm = match.group(1)
     body = text[match.end() :]
@@ -69,7 +75,51 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
 
         data[key] = value
 
-    return data, body.lstrip("\r\n")
+    return data, body.lstrip("\r\n"), raw_fm, newline
+
+
+def serialize_frontmatter_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "[" + ", ".join(json.dumps(str(v), ensure_ascii=False) for v in value) + "]"
+    text = str(value)
+    if not text:
+        return ""
+    if any(ch in text for ch in [":", "#", "[", "]", "{", "}", "\n", "\r"]) or text != text.strip():
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def upsert_frontmatter_fields(markdown_file: Path, updates: dict[str, str]) -> None:
+    """Update or append simple top-level frontmatter fields."""
+    original = markdown_file.read_text(encoding="utf-8")
+    data, body, raw_fm, newline = parse_frontmatter(original)
+    if not raw_fm:
+        raw_fm = ""
+
+    lines = raw_fm.splitlines()
+    updated_keys: set[str] = set()
+    out_lines: list[str] = []
+    for line in lines:
+        if ":" not in line or line.lstrip().startswith("#"):
+            out_lines.append(line)
+            continue
+        key = line.split(":", 1)[0].strip()
+        if key in updates:
+            out_lines.append(f"{key}: {serialize_frontmatter_value(updates[key])}")
+            updated_keys.add(key)
+        else:
+            out_lines.append(line)
+
+    for key, value in updates.items():
+        if key not in updated_keys:
+            out_lines.append(f"{key}: {serialize_frontmatter_value(value)}")
+
+    new_text = "---" + newline + newline.join(out_lines).rstrip() + newline + "---" + newline + newline + body
+    markdown_file.write_text(new_text, encoding="utf-8")
 
 
 def normalize_tags(value: Any) -> list[dict[str, str]]:
@@ -83,12 +133,14 @@ def normalize_tags(value: Any) -> list[dict[str, str]]:
         return []
 
     tags: list[dict[str, str]] = []
-    for name in names:
-        # Hashnode accepts TagInput with name/slug/id. Supplying both name and
-        # slug makes drafts readable even when tag IDs are not known yet.
+    for name in names[:5]:
         slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or name.lower()
         tags.append({"name": name, "slug": slug})
     return tags
+
+
+def truthy(value: Any) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 def is_external_url(url: str) -> bool:
@@ -105,42 +157,26 @@ def normalize_local_asset_url(url: str, markdown_path: Path, raw_base_url: str |
     markdown_dir = markdown_path.resolve().parent
 
     if url.startswith("/"):
-        rel = url.lstrip("/")
+        candidate = (repo_root / url.lstrip("/")).resolve()
     else:
         abs_from_markdown = (markdown_dir / url).resolve()
         abs_from_root = (repo_root / url).resolve()
-        # Prefer the path relative to the markdown file when it exists. If it
-        # does not exist, fall back to repo-root relative paths. This lets both
-        # `![](assets/x.png)` from a root-level post and from a nested draft work
-        # in the common repo layout.
-        abs_img = abs_from_markdown if abs_from_markdown.exists() else abs_from_root
-        try:
-            rel = abs_img.relative_to(repo_root).as_posix()
-        except ValueError:
-            # Do not invent a GitHub raw URL for paths outside this repository.
-            # Leaving the original URL unchanged makes the issue visible to the
-            # author instead of silently pointing Hashnode at the wrong asset.
-            return url
+        candidate = abs_from_markdown if abs_from_markdown.exists() else abs_from_root
 
+    try:
+        rel = candidate.relative_to(repo_root).as_posix()
+    except ValueError:
+        return url
     return f"{raw_base_url}/{rel}"
 
 
 def rewrite_relative_images(markdown: str, markdown_path: Path, raw_base_url: str | None) -> str:
-    """Rewrite relative Markdown image URLs to a public raw GitHub base URL.
-
-    Hashnode cannot render local files like ./assets/foo.png. If raw_base_url is
-    provided, relative image paths are converted to:
-      {raw_base_url}/{path-relative-to-repo-root}
-    """
     if not raw_base_url:
         return markdown
-
-    raw_base_url = raw_base_url.rstrip("/")
 
     def replace(match: re.Match[str]) -> str:
         alt = match.group(1)
         url_and_title = match.group(2).strip()
-        # Keep optional title if present: image.png "title"
         parts = re.match(r"([^\s]+)(.*)", url_and_title)
         if not parts:
             return match.group(0)
@@ -154,27 +190,57 @@ def rewrite_relative_images(markdown: str, markdown_path: Path, raw_base_url: st
     return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", replace, markdown)
 
 
+def explain_non_json_response(response: urllib.response.addinfourl, body: str) -> HashnodeAPIError:
+    final_url = response.geturl()
+    content_type = response.headers.get("content-type", "")
+    parsed = urllib.parse.urlparse(final_url)
+    body_start = re.sub(r"\s+", " ", body[:240]).strip()
+    if "paid-access" in final_url or "GraphQL API is moving to a paid offering" in body:
+        return HashnodeAPIError(
+            "Hashnode API returned HTML instead of JSON. Likely cause: this publication "
+            "does not have Hashnode Pro / GraphQL API access enabled. "
+            f"Final URL: {final_url}. Upgrade/check billing: https://hashnode.com/settings/billing"
+        )
+    return HashnodeAPIError(
+        "Hashnode API returned a non-JSON response. "
+        f"Final URL: {parsed.netloc}{parsed.path}; Content-Type: {content_type}; Body: {body_start}"
+    )
+
+
 def graphql_request(query: str, variables: dict[str, Any], token: str) -> dict[str, Any]:
     req = urllib.request.Request(
         HASHNODE_ENDPOINT,
         data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
         headers={
             "Content-Type": "application/json",
-            # Hashnode examples and current MCP implementations send the raw PAT.
+            "Accept": "application/json",
+            # Hashnode requires the raw PAT. No Bearer prefix.
             "Authorization": token,
-            "User-Agent": "hashnode-draft-action/1.0",
+            "User-Agent": "hashnode-controlled-action/2.0",
         },
         method="POST",
     )
     try:
         with urllib.request.urlopen(req, timeout=45) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+            raw = response.read().decode("utf-8", errors="replace")
+            content_type = response.headers.get("content-type", "")
+            if "json" not in content_type.lower():
+                raise explain_non_json_response(response, raw)
+            payload = json.loads(raw)
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"Hashnode HTTP {exc.code}: {body}") from exc
+        if exc.code in {301, 302}:
+            raise HashnodeAPIError(
+                "Hashnode API redirected instead of returning JSON. Likely cause: "
+                "GraphQL API access requires a Pro publication plan. "
+                "Check https://hashnode.com/settings/billing"
+            ) from exc
+        raise HashnodeAPIError(f"Hashnode HTTP {exc.code}: {body}") from exc
+    except json.JSONDecodeError as exc:
+        raise HashnodeAPIError(f"Hashnode returned invalid JSON: {exc}") from exc
 
     if payload.get("errors"):
-        raise RuntimeError("Hashnode GraphQL errors: " + json.dumps(payload["errors"], ensure_ascii=False))
+        raise HashnodeAPIError("Hashnode GraphQL errors: " + json.dumps(payload["errors"], ensure_ascii=False))
     return payload.get("data") or {}
 
 
@@ -191,94 +257,196 @@ def get_publication_id(host: str, token: str) -> str:
     data = graphql_request(query, {"host": host}, token)
     publication = data.get("publication")
     if not publication or not publication.get("id"):
-        raise RuntimeError(f"Could not find Hashnode publication for host: {host}")
+        raise HashnodeAPIError(f"Could not find Hashnode publication for host: {host}")
     print(f"Resolved publication: {publication.get('title')} ({publication.get('url')})", file=sys.stderr)
     return publication["id"]
 
 
-def build_draft_input(
-    markdown_file: Path,
-    publication_id: str,
-    raw_base_url: str | None,
-) -> dict[str, Any]:
+def first_value(frontmatter: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = frontmatter.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def build_post_input(markdown_file: Path, publication_id: str, raw_base_url: str | None) -> tuple[dict[str, Any], dict[str, Any]]:
     text = markdown_file.read_text(encoding="utf-8")
-    frontmatter, body = parse_frontmatter(text)
+    frontmatter, body, _, _ = parse_frontmatter(text)
     body = rewrite_relative_images(body, markdown_file, raw_base_url)
 
     title = str(frontmatter.get("title") or "").strip()
     if not title:
         raise RuntimeError("Missing required frontmatter: title")
 
-    draft_input: dict[str, Any] = {
+    post_input: dict[str, Any] = {
         "publicationId": publication_id,
         "title": title,
         "contentMarkdown": body,
     }
 
-    if frontmatter.get("subtitle"):
-        draft_input["subtitle"] = str(frontmatter["subtitle"])
+    subtitle = first_value(frontmatter, "subtitle", "description")
+    if subtitle:
+        post_input["subtitle"] = str(subtitle)
     if frontmatter.get("slug"):
-        draft_input["slug"] = str(frontmatter["slug"])
-        draft_input["settings"] = {"slugOverridden": True}
-    if frontmatter.get("canonical"):
-        draft_input["originalArticleURL"] = str(frontmatter["canonical"])
-    if frontmatter.get("disableComments"):
-        draft_input["disableComments"] = str(frontmatter["disableComments"]).lower() == "true"
+        post_input["slug"] = str(frontmatter["slug"])
+        post_input["settings"] = {"slugOverridden": True}
+    canonical = first_value(frontmatter, "canonical", "canonical_url", "originalArticleURL")
+    if canonical:
+        post_input["originalArticleURL"] = str(canonical)
+    if frontmatter.get("disableComments") is not None:
+        post_input["disableComments"] = truthy(frontmatter["disableComments"])
 
     tags = normalize_tags(frontmatter.get("tags"))
     if tags:
-        draft_input["tags"] = tags
+        post_input["tags"] = tags
 
-    cover = frontmatter.get("cover") or frontmatter.get("ogImage")
+    cover = first_value(frontmatter, "cover", "cover_image", "ogImage")
+    cover_url = None
     if cover:
         cover_url = normalize_local_asset_url(str(cover), markdown_file, raw_base_url)
         if is_external_url(cover_url):
-            draft_input["coverImageOptions"] = {"coverImageURL": cover_url}
+            post_input["coverImageOptions"] = {"coverImageURL": cover_url}
 
     meta: dict[str, str] = {}
     if frontmatter.get("seoTitle"):
         meta["title"] = str(frontmatter["seoTitle"])
     if frontmatter.get("seoDescription"):
         meta["description"] = str(frontmatter["seoDescription"])
-    if frontmatter.get("ogImage"):
-        og_image_url = normalize_local_asset_url(str(frontmatter["ogImage"]), markdown_file, raw_base_url)
+    og_image = first_value(frontmatter, "ogImage", "cover", "cover_image")
+    if og_image:
+        og_image_url = normalize_local_asset_url(str(og_image), markdown_file, raw_base_url)
         if is_external_url(og_image_url):
             meta["image"] = og_image_url
     if meta:
-        draft_input["metaTags"] = meta
+        post_input["metaTags"] = meta
 
-    return draft_input
+    return post_input, frontmatter
 
 
-def create_draft(draft_input: dict[str, Any], token: str) -> dict[str, Any]:
+def create_draft(post_input: dict[str, Any], token: str) -> dict[str, Any]:
     mutation = """
     mutation CreateDraft($input: CreateDraftInput!) {
       createDraft(input: $input) {
-        draft {
-          id
-          title
-          slug
-          updatedAt
-          author { username }
-        }
+        draft { id title slug updatedAt author { username } }
       }
     }
     """
-    data = graphql_request(mutation, {"input": draft_input}, token)
+    data = graphql_request(mutation, {"input": post_input}, token)
     draft = (data.get("createDraft") or {}).get("draft")
     if not draft:
-        raise RuntimeError("Hashnode did not return a draft: " + json.dumps(data, ensure_ascii=False))
+        raise HashnodeAPIError("Hashnode did not return a draft: " + json.dumps(data, ensure_ascii=False))
     return draft
 
 
+def update_draft(draft_id: str, post_input: dict[str, Any], token: str) -> dict[str, Any]:
+    mutation = """
+    mutation UpdateDraft($input: UpdateDraftInput!) {
+      updateDraft(input: $input) {
+        draft { id title slug updatedAt author { username } }
+      }
+    }
+    """
+    update_input = {k: v for k, v in post_input.items() if k != "publicationId"}
+    update_input["id"] = draft_id
+    data = graphql_request(mutation, {"input": update_input}, token)
+    draft = (data.get("updateDraft") or {}).get("draft")
+    if not draft:
+        raise HashnodeAPIError("Hashnode did not return an updated draft: " + json.dumps(data, ensure_ascii=False))
+    return draft
+
+
+def publish_draft(draft_id: str, token: str) -> dict[str, Any]:
+    mutation = """
+    mutation PublishDraft($input: PublishDraftInput!) {
+      publishDraft(input: $input) {
+        post { id title slug url publishedAt }
+      }
+    }
+    """
+    data = graphql_request(mutation, {"input": {"draftId": draft_id}}, token)
+    post = (data.get("publishDraft") or {}).get("post")
+    if not post:
+        raise HashnodeAPIError("Hashnode did not return a published post: " + json.dumps(data, ensure_ascii=False))
+    return post
+
+
+def publish_post(post_input: dict[str, Any], token: str) -> dict[str, Any]:
+    mutation = """
+    mutation PublishPost($input: PublishPostInput!) {
+      publishPost(input: $input) {
+        post { id title slug url publishedAt }
+      }
+    }
+    """
+    data = graphql_request(mutation, {"input": post_input}, token)
+    post = (data.get("publishPost") or {}).get("post")
+    if not post:
+        raise HashnodeAPIError("Hashnode did not return a published post: " + json.dumps(data, ensure_ascii=False))
+    return post
+
+
+def update_post(post_id: str, post_input: dict[str, Any], token: str) -> dict[str, Any]:
+    mutation = """
+    mutation UpdatePost($input: UpdatePostInput!) {
+      updatePost(input: $input) {
+        post { id title slug url updatedAt }
+      }
+    }
+    """
+    # UpdatePostInput is narrower than PublishPostInput in maintained Hashnode
+    # MCP implementations. Do not send publicationId or publish-only fields.
+    allowed_update_fields = {
+        "title",
+        "contentMarkdown",
+        "subtitle",
+        "tags",
+        "coverImageOptions",
+    }
+    update_input = {k: v for k, v in post_input.items() if k in allowed_update_fields}
+    update_input["id"] = post_id
+    data = graphql_request(mutation, {"input": update_input}, token)
+    post = (data.get("updatePost") or {}).get("post")
+    if not post:
+        raise HashnodeAPIError("Hashnode did not return an updated post: " + json.dumps(data, ensure_ascii=False))
+    return post
+
+
+def resolve_action(cli_action: str | None, frontmatter: dict[str, Any]) -> str:
+    action = cli_action or str(first_value(frontmatter, "hashnode_action", "action") or "draft")
+    action = action.strip().lower()
+    aliases = {
+        "create-draft": "draft",
+        "create_draft": "draft",
+        "publish_post": "publish",
+        "publishpost": "publish",
+        "publish_draft": "publish-draft",
+        "publishdraft": "publish-draft",
+        "update_draft": "update-draft",
+        "updatedraft": "update-draft",
+        "update_post": "update-post",
+        "updatepost": "update-post",
+        "check": "api-check",
+    }
+    action = aliases.get(action, action)
+    allowed = {"validate", "api-check", "draft", "update-draft", "publish-draft", "publish", "update-post"}
+    if action not in allowed:
+        raise RuntimeError(f"Unsupported action '{action}'. Allowed: {', '.join(sorted(allowed))}")
+    return action
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Create a Hashnode draft from Markdown")
+    parser = argparse.ArgumentParser(description="Controlled Hashnode publishing from Markdown")
     parser.add_argument("markdown_file", type=Path)
+    parser.add_argument("--action", choices=["validate", "api-check", "draft", "update-draft", "publish-draft", "publish", "update-post"])
     parser.add_argument("--publication-id", default=os.getenv("HASHNODE_PUBLICATION_ID"))
     parser.add_argument("--publication-host", default=os.getenv("HASHNODE_PUBLICATION_HOST"))
-    parser.add_argument("--token", default=os.getenv("HASHNODE_API_TOKEN"))
+    parser.add_argument("--token", default=os.getenv("HASHNODE_API_TOKEN") or os.getenv("HASHNODE_TOKEN"))
     parser.add_argument("--raw-base-url", default=os.getenv("RAW_BASE_URL"))
+    parser.add_argument("--draft-id", default=os.getenv("HASHNODE_DRAFT_ID"))
+    parser.add_argument("--post-id", default=os.getenv("HASHNODE_POST_ID"))
     parser.add_argument("--dry-run", action="store_true", help="Print payload without calling Hashnode")
+    parser.add_argument("--write-back", action="store_true", help="Write draft/post IDs back to markdown frontmatter")
     args = parser.parse_args()
 
     if not args.markdown_file.exists():
@@ -287,27 +455,71 @@ def main() -> int:
     token = args.token
     publication_id = args.publication_id
 
+    raw_text = args.markdown_file.read_text(encoding="utf-8")
+    frontmatter, _, _, _ = parse_frontmatter(raw_text)
+    action = resolve_action(args.action, frontmatter)
+
     if not publication_id:
-        if not args.publication_host:
-            raise SystemExit("Need HASHNODE_PUBLICATION_ID or HASHNODE_PUBLICATION_HOST")
-        if args.dry_run and not token:
+        if args.dry_run or action == "validate":
             publication_id = "dry-run-publication-id"
         else:
+            if not args.publication_host:
+                raise SystemExit("Need HASHNODE_PUBLICATION_ID or HASHNODE_PUBLICATION_HOST")
             if not token:
                 raise SystemExit("Need HASHNODE_API_TOKEN to resolve HASHNODE_PUBLICATION_HOST")
             publication_id = get_publication_id(args.publication_host, token)
 
-    draft_input = build_draft_input(args.markdown_file, publication_id, args.raw_base_url)
+    post_input, frontmatter = build_post_input(args.markdown_file, publication_id, args.raw_base_url)
+    draft_id = args.draft_id or first_value(frontmatter, "hashnode_draft_id", "draftId")
+    post_id = args.post_id or first_value(frontmatter, "hashnode_article_id", "hashnode_post_id", "articleId", "postId")
 
-    if args.dry_run:
-        print(json.dumps({"input": draft_input}, ensure_ascii=False, indent=2))
+    if action == "validate" or args.dry_run:
+        print(json.dumps({"action": action, "input": post_input, "draftId": draft_id, "postId": post_id}, ensure_ascii=False, indent=2))
         return 0
 
     if not token:
         raise SystemExit("Need HASHNODE_API_TOKEN")
 
-    draft = create_draft(draft_input, token)
-    print(json.dumps({"draft": draft}, ensure_ascii=False, indent=2))
+    if action == "api-check":
+        print(json.dumps({"ok": True, "publicationId": publication_id}, ensure_ascii=False, indent=2))
+        return 0
+
+    updates: dict[str, str] = {}
+    result: dict[str, Any]
+
+    if action == "draft":
+        if draft_id:
+            result = {"draft": update_draft(str(draft_id), post_input, token), "operation": "update-draft"}
+        else:
+            draft = create_draft(post_input, token)
+            updates["hashnode_draft_id"] = draft["id"]
+            result = {"draft": draft, "operation": "create-draft"}
+    elif action == "update-draft":
+        if not draft_id:
+            raise RuntimeError("Need hashnode_draft_id / draftId / --draft-id for update-draft")
+        result = {"draft": update_draft(str(draft_id), post_input, token), "operation": "update-draft"}
+    elif action == "publish-draft":
+        if not draft_id:
+            raise RuntimeError("Need hashnode_draft_id / draftId / --draft-id for publish-draft")
+        post = publish_draft(str(draft_id), token)
+        updates["hashnode_article_id"] = post["id"]
+        result = {"post": post, "operation": "publish-draft"}
+    elif action == "publish":
+        post = publish_post(post_input, token)
+        updates["hashnode_article_id"] = post["id"]
+        result = {"post": post, "operation": "publish"}
+    elif action == "update-post":
+        if not post_id:
+            raise RuntimeError("Need hashnode_article_id / articleId / --post-id for update-post")
+        result = {"post": update_post(str(post_id), post_input, token), "operation": "update-post"}
+    else:
+        raise RuntimeError(f"Unhandled action: {action}")
+
+    if args.write_back and updates:
+        upsert_frontmatter_fields(args.markdown_file, updates)
+        result["frontmatterUpdated"] = updates
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Expand Hashnode workflow from draft-only into a controlled publish workflow
- Add explicit actions: validate, api-check, draft, update-draft, publish-draft, publish, update-post
- Add safer frontmatter write-back for draft/post IDs
- Add clear non-JSON/paid API access error messages for Hashnode GraphQL responses
- Avoid GitHub Actions script injection by passing workflow inputs through env vars

## Test Plan
- python -m py_compile scripts/hashnode_create_draft.py
- Local dry-run for validate, draft, publish, update-draft, publish-draft, update-post, api-check
- Local frontmatter write-back / hashnode_article_id round-trip check
- Local dummy-token API check verifies paid-access HTML response becomes actionable error
- Security scan for added hardcoded secrets/dangerous calls

Note: real Hashnode API calls still require Hashnode Pro/API access on the publication.